### PR TITLE
Fix token validation message spelling

### DIFF
--- a/routes/authRouter.ts
+++ b/routes/authRouter.ts
@@ -13,7 +13,7 @@ router.post(
 
 // ----------VALIDATE TOKEN -----------------
 router.get("/validate-token", verifyToken, (req: Request, res: Response) => {
-  res.status(200).send({ message: "Token validation successfull", success: true });
+  res.status(200).send({ message: "Token validation successful", success: true });
 });
 
 // ----------LOGOUT USER -----------------


### PR DESCRIPTION
## Summary
- fix typo in token validation response message

## Testing
- `npm test` *(fails: Missing script: "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68a09fb846e0832bb7244455b191b340